### PR TITLE
Changement de BITRISE_BUILD_NUMBER (déprécié) en CI_BUILD_NUMBER

### DIFF
--- a/Forge.rb
+++ b/Forge.rb
@@ -218,15 +218,27 @@ private_lane :gym_with_workspace do |options|
   )
 end
 
-desc 'Extract the build number from bitrise into environment variables and set in AppVersion.xcconfig'
+def resolve_ci_build_number
+  ci_build_number = ENV['CI_BUILD_NUMBER']
+  return ci_build_number unless ci_build_number.nil? || ci_build_number.empty?
+  legacy_build_number = ENV['BITRISE_BUILD_NUMBER']
+  unless legacy_build_number.nil? || legacy_build_number.empty?
+    UI.important('[DEPRECATION] BITRISE_BUILD_NUMBER is deprecated and will be removed in a future Forge release. Set CI_BUILD_NUMBER instead.')
+    return legacy_build_number
+  end
+  nil
+end
+
+desc 'Extract the build number from the CI environment and set it in AppVersion.xcconfig'
 private_lane :set_build_number do
   UI.message 'Extracting Build number'
-  if ENV['BITRISE_BUILD_NUMBER']
-    UI.message "==> bitrise build number : #{ENV['BITRISE_BUILD_NUMBER']}"
+  build_number = resolve_ci_build_number
+  if build_number
+    UI.message "==> CI build number : #{build_number}"
     update_xcconfig_value(
       path: ENV.fetch('APP_VERSION_PATH', nil),
       name: 'APP_BUILD_NUMBER',
-      value: ENV['BITRISE_BUILD_NUMBER']
+      value: build_number
     )
   end
 end
@@ -243,7 +255,7 @@ private_lane :get_versions_from_project do
     name: 'APP_BUILD_NUMBER'
   )
   ENV['VERSION_NUMBER'] = current_version
-  ENV['BUILD_NUMBER'] = ENV['BITRISE_BUILD_NUMBER'] || current_build_number
+  ENV['BUILD_NUMBER'] = resolve_ci_build_number || current_build_number
   UI.message "==> v#{ENV['VERSION_NUMBER']} (#{ENV['BUILD_NUMBER']})"
 end
 


### PR DESCRIPTION
En faisant la migration vers Codemagic j'ai remarqué qu'on devait set BITRISE_BUILD_NUMBER parce qu'il était récupéré dans la Forge et je me suis dit que ce serait une bonne idée de changer ce nom qui n'est plus pertinent.

Ce changement introduit CI_BUILD_NUMBER, tout en gardant BITRISE_BUILD_NUMBER en fallback pour la rétrocompatibilité (mais qu'on va quand même finir par enlever).

J'ai donc ajouté le helper resolve_ci_build_number pour  récupérer le CI_BUILD_NUMBER tout en ayant un fallback sur BITRISE_BUILD_NUMBER pour les projets n'ayant pas encore mis à jour la variable.
ça affecte 2 lanes (set_build_number et get_versions_from_project) qui utilisent maintenant ce helper.
Le helper ajoute aussi un avertissement de dépréciation (UI.important blablabla) quand seul BITRISE_BUILD_NUMBER est défini.

Niveau rétrocompatibilité : aucune rupture avec les projets qui utilisent encore BITRISE_BUILD_NUMBER, ils verront juste un avertissement les invitant à migrer vers CI_BUILD_NUMBER.

Par contre à terme il faudra prévoir la suppression de BITRISE_BUILD_NUMBER qui n'a plus lieu d'être.