### PR TITLE
Fix: remove HOMEBREW_NO_AUTO_UPDATE in brew install

### DIFF
--- a/Forge.rb
+++ b/Forge.rb
@@ -39,7 +39,7 @@ end
 
 private_lane :brew_install do |options|
   package = options[:package]
-  sh("NONINTERACTIVE=1 HOMEBREW_NO_AUTO_UPDATE=1 brew install #{package}")
+  sh("NONINTERACTIVE=1 brew install #{package}")
 end
 
 ###########################


### PR DESCRIPTION
Removing HOMEBREW_NO_AUTO_UPDATE as it installed latest tools on CI and never updated installed ones on clients